### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # extenum
 
 [![Build Status](https://travis-ci.org/t2y/extenum.svg?branch=master)](https://travis-ci.org/t2y/extenum/)
-[![Latest Version](https://pypip.in/version/extenum/badge.svg)](https://pypi.python.org/pypi/extenum/)
-[![Downloads](https://pypip.in/download/extenum/badge.svg)](https://pypi.python.org/pypi/extenum/)
-[![License](https://pypip.in/license/extenum/badge.svg)](https://pypi.python.org/pypi/extenum/)
+[![Latest Version](https://img.shields.io/pypi/v/extenum.svg)](https://pypi.python.org/pypi/extenum/)
+[![Downloads](https://img.shields.io/pypi/dm/extenum.svg)](https://pypi.python.org/pypi/extenum/)
+[![License](https://img.shields.io/pypi/l/extenum.svg)](https://pypi.python.org/pypi/extenum/)
 
 
 Extended Enum classes for Python 3 enum module.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20extenum))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `extenum`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.